### PR TITLE
Site build configuration as a literate org file.

### DIFF
--- a/build-site.org
+++ b/build-site.org
@@ -1,0 +1,76 @@
+#+TITLE: Website Publishing: Build config
+#+STARTUP: content
+
+* Emacs Build Configuration
+** Package manager settings
+#+BEGIN_SRC emacs-lisp :tangle ./build-site.el
+  ;; Set the package installation directory so that packages aren't stored in the
+  ;; ~/.emacs.d/elpa path.
+  (require 'package)
+  (setq package-user-dir (expand-file-name "./.packages"))
+  (setq package-archives '(("melpa" . "https://melpa.org/packages/")
+                           ("elpa" . "https://elpa.gnu.org/packages/")))
+#+END_SRC
+** Initialize package system
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  ;; Initialize the package system
+  (package-initialize  (unless package-archive-contents
+    (package-refresh-contents)))
+#+END_SRC
+** No backups or temp files
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  (setq make-backup-files nil)
+#+END_SRC
+** URL handeler mode to include external files
+#+BEGIN_SRC emacs-lisp :tangle ./build-site.el
+  (url-handler-mode 1)
+#+END_SRC
+** Install dependencies
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  (package-install 'htmlize)
+#+END_SRC
+** Load publishing system
+#+BEGIN_SRC emacs-lisp :tangle ./build-site.el
+  (require 'ox-publish)
+#+END_SRC
+** Customize HTML output
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  ;; Customize the HTML output
+  (setq org-html-validation-link nil            ;; Don't show validation link
+        org-html-head-include-scripts nil       ;; Use our own scripts
+        org-html-head-include-default-style nil ;; Use our own styles
+        org-html-head "<link rel=\"stylesheet\" href=\"https://cdn.simplecss.org/simple.min.css\" />")
+#+END_SRC
+** Publishing project properties
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  ;; Define the publishing project
+  (setq org-publish-project-alist
+        (list
+         (list "org-site:main"
+               :recursive t
+               :base-directory "./content"
+               :publishing-function 'org-html-publish-to-html
+               :publishing-directory "./public"
+               :with-author nil           ;; Don't include author name
+               :with-creator t            ;; Include Emacs and Org versions in footer
+               :with-toc t                ;; Include a table of contents
+               :section-numbers nil       ;; Don't include section numbers
+               :time-stamp-file nil)))    ;; Don't include time stamp in file
+
+#+END_SRC
+** Generate Output
+#+BEGIN_SRC emacs-lisp :tangle  ./build-site.el
+  ;; Generate the site output
+  (org-publish-all t)
+  (message "Build complete!")
+#+END_SRC
+* Build
+
+Add the following block in the =build.sh= script. First line evaluates thin org file and creates a =build.el= file which contains all the publishing configuration. The second line evaluates =build.el= file itself and publish the web pages. And the final line removes =build.el= file.
+
+#+BEGIN_SRC shell :tangle no
+  #!/bin/bash
+  emacs -Q --batch --eval "(require 'org)" --eval '(org-babel-tangle-file "build-site.org")'
+  emacs -Q --script build-site.el
+  rm build.el
+#+END_SRC

--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,4 @@
 #!/bin/sh
+emacs -Q --batch --eval "(require 'org)" --eval '(org-babel-tangle-file "build-site.org")'
 emacs -Q --script build-site.el
+rm build.el


### PR DESCRIPTION
This edit contains the website publishing configuration as a literate org file (which can have detailed explanation  of each settings). The edit in the shell script first tangles the `build-site.org` file into `build-site.el` file and then executes the lisp code. 